### PR TITLE
Add git submodule bits to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ You'll need a Raspberry Pi running rasbian.  On the Pi, run:
 
     git clone https://github.com/tomwilkie/awesomation.git
     cd awesomation
+    git submodule init; git submodule update
     cd third_party/open-zwave; make; make install
     cd third_party/python-openzwave; make; make install
     cd third_party/wiringPi; make; make install


### PR DESCRIPTION
Running `make runpi`

Fails with `make: *** No rule to make target 'dist/static/js/bootstrap.js', needed by 'dist/static'.  Stop.`

I think because git submodules need pulling.